### PR TITLE
Fix Debug Host in Local

### DIFF
--- a/src/press/models.py
+++ b/src/press/models.py
@@ -208,16 +208,17 @@ class Press(AbstractSiteModel):
         request = logic.get_current_request()
         if settings.DEBUG and request:
             port = request.get_port()
+            domain = request.get_host()
         else:
             port = None
+            domain = self.domain
         if path is not None:
             # Ignore duplicate site code if provided in code
             if path.startswith(_path):
                 path = path[len(_path):]
             _path += path
-
         return logic.build_url(
-            netloc=self.domain,
+            netloc=domain,
             scheme=self._get_scheme(),
             port=port,
             path=_path,


### PR DESCRIPTION
## Problem / Objective
Fix local host in `Press.site_path_url` for DEBUG mode
```python
def site_path_url(self, child_site, path=None):
        """Returns the path mode URL of a site relative to its press"""
        _path = "/" + child_site.code
        request = logic.get_current_request()
        if settings.DEBUG and request:
            port = request.get_port()
            domain = request.get_host()
        else:
            port = None
            domain = self.domain
        if path is not None:
            # Ignore duplicate site code if provided in code
            if path.startswith(_path):
                path = path[len(_path):]
            _path += path
        return logic.build_url(
            netloc=domain,
            scheme=self._get_scheme(),
            port=port,
            path=_path,
        )
```