### PR TITLE
Add new Required Senior Editor option

### DIFF
--- a/src/core/logic.py
+++ b/src/core/logic.py
@@ -357,6 +357,10 @@ def get_settings_to_edit(display_group, journal, user):
                 'object': setting_handler.get_setting('general', 'draft_decisions', journal),
             },
             {
+                'name': 'required_senior_editor',
+                'object': setting_handler.get_setting('general', 'required_senior_editor', journal),
+            },
+            {
                 'name': 'default_review_form',
                 'object': setting_handler.get_setting('general', 'default_review_form', journal),
                 'choices': review_form_choices

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -730,12 +730,6 @@ class Setting(models.Model):
             journal=None,
     )
 
-    def journal_current_setting_value(self, journal):
-        return SettingValue.objects.get(
-            setting=self,
-            journal=journal
-        )
-
     def validate(self, value):
         if self.types in self.VALIDATORS:
             for validator in self.VALIDATORS[self.name]:

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -730,6 +730,12 @@ class Setting(models.Model):
             journal=None,
     )
 
+    def journal_current_setting_value(self, journal):
+        return SettingValue.objects.get(
+            setting=self,
+            journal=journal
+        )
+
     def validate(self, value):
         if self.types in self.VALIDATORS:
             for validator in self.VALIDATORS[self.name]:

--- a/src/core/templatetags/roles.py
+++ b/src/core/templatetags/roles.py
@@ -1,6 +1,7 @@
 from django import template
 
 from core import models
+from review import models as review_models
 
 register = template.Library()
 
@@ -47,3 +48,12 @@ def role_id(request, role_slug):
         return role.pk
     except models.Role.DoesNotExist:
         return 0
+
+
+@register.simple_tag
+def editor_can_access(request, article):
+    required_senior_editor = models.Setting.objects.get(
+        name='required_senior_editor'
+    ).journal_current_setting_value(journal=request.journal).value
+    is_editor = user_has_role(request, 'editor')
+    return is_editor and request.user in article.editor_list() if required_senior_editor else is_editor

--- a/src/core/templatetags/roles.py
+++ b/src/core/templatetags/roles.py
@@ -1,7 +1,7 @@
 from django import template
 
 from core import models
-from review import models as review_models
+from utils import setting_handler
 
 register = template.Library()
 
@@ -52,8 +52,6 @@ def role_id(request, role_slug):
 
 @register.simple_tag
 def editor_can_access(request, article):
-    required_senior_editor = models.Setting.objects.get(
-        name='required_senior_editor'
-    ).journal_current_setting_value(journal=request.journal).value
+    required_senior_editor = setting_handler.get_setting('general', 'required_senior_editor', request.journal).value
     is_editor = user_has_role(request, 'editor')
     return is_editor and request.user in article.editor_list() if required_senior_editor else is_editor

--- a/src/templates/admin/elements/forms/group_review.html
+++ b/src/templates/admin/elements/forms/group_review.html
@@ -9,6 +9,7 @@
     {% include "admin/elements/forms/field.html" with field=edit_form.default_review_visibility %}
     {% include "admin/elements/forms/field.html" with field=edit_form.enable_one_click_access %}
     {% include "admin/elements/forms/field.html" with field=edit_form.draft_decisions %}
+    {% include "admin/elements/forms/field.html" with field=edit_form.required_senior_editor %}
     {% include "admin/elements/forms/field.html" with field=edit_form.enable_suggested_reviewers %}
     {% include "admin/elements/forms/field.html" with field=edit_form.display_past_reviewers %}
 </div>

--- a/src/templates/admin/review/unassigned_article.html
+++ b/src/templates/admin/review/unassigned_article.html
@@ -16,6 +16,7 @@
 {% block body %}
     {% user_has_role request 'editor' as is_editor %}
     {% user_has_role request 'section-editor' as is_section_editor %}
+    {% editor_can_access request article as editor_can_access %}
     <div class="large-7 columns">
         <div class="box">
             <div class="title-area">
@@ -216,7 +217,7 @@
                         <th>Name</th>
                         <th>Email</th>
                         <th>Type</th>
-                        {% if is_editor %}
+                        {% if editor_can_access %}
                             <th></th>
                         {% endif %}
                     </tr>
@@ -225,7 +226,7 @@
                             <td>{{ assignment.editor.full_name }}</td>
                             <td>{{ assignment.editor.email }}</td>
                             <td>{{ assignment.editor_type|capfirst }}</td>
-                            {% if is_editor %}
+                            {% if editor_can_access %}
                                 <td><a href="{% url 'review_unassign_editor' article.id assignment.editor.id %}">Remove</a>
                             {% endif %}
                             </td>
@@ -240,6 +241,78 @@
         </div>
 
         {% if is_editor %}
+        {% if journal_settings.general.required_senior_editor %}
+        <div class="box">
+            <div class="title-area">
+                <h2>Add Senior Editors</h2>
+            </div>
+            <div class="content">
+                <table class="scroll small" id="editors">
+                    <thead>
+                    <tr>
+                        <th>Name</th>
+                        <th>Email</th>
+                        <th>Type</th>
+                        <th></th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    {% for account_role in editors %}
+                        <tr>
+                            <td>{{ account_role.user.full_name }}</td>
+                            <td>{{ account_role.user.email }}</td>
+                            <td>Editor</td>
+                            <td>
+                                <a href="{% url 'review_assign_editor' article.pk account_role.user.id 'editor' %}?return={% url 'review_unassigned_article' article.pk %}">
+                                    Add{% if account_role.user == request.user %} Self{% endif %}
+                                </a>
+                            </td>
+                        </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        {% if editor_can_access %}
+        <div class="box">
+            <div class="title-area">
+                <h2>Add Section Editors</h2>
+            </div>
+            <div class="content">
+                <table class="scroll small" id="editors">
+                    <thead>
+                    <tr>
+                        <th>Name</th>
+                        <th>Email</th>
+                        <th>Type</th>
+                        <th></th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    {% for account_role in section_editors %}
+                        <tr>
+                            <td>{{ account_role.user.full_name }}</td>
+                            <td>{{ account_role.user.email }}</td>
+                            <td>Section Editor</td>
+                            <td>
+                                <a href="{% url 'review_assign_editor' article.pk account_role.user.id 'section-editor' %}?return={% url 'review_unassigned_article' article.pk %}">Add</a>
+                            </td>
+                        </tr>
+                    {% endfor %}
+                    {% if not section_editors and not editors %}
+                        <tr>
+                            <td colspan="4">No matches</td>
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                        </tr>
+                    {% endif %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        {% endif %}
+        {% else %}
         <div class="box">
             <div class="title-area">
                 <h2>Add Editors</h2>
@@ -291,6 +364,7 @@
         </div>
         {% endif %}
         {% endif %}
+        {% endif %}
         <div class="box">
             <div class="title-area">
                 <h2>Actions</h2>
@@ -302,7 +376,7 @@
                             {% trans 'This paper has not had an automatic plagiarism check. If you wish to do so you can run a' %} <a href="{% url 'review_unassigned_article' article.pk %}#files-block">{% trans 'Similarity Check via iThenticate' %}</a> .</small></p>
                         </div>
                     {% endif %}
-                    {% if article.editors %}
+                    {% if editor_can_access or is_section_editor and request.user in article.editor_list %}
                         <ul class="menu vertical actions">
                             <li>
                                 <a href="{% url 'review_move_to_review' article.pk %}?return={% url 'review_in_review' article.pk %}"><i
@@ -316,7 +390,7 @@
                         </ul>
                     {% else %}
                         <div class="bs-callout bs-callout-info">
-                            <small>Before you can perform actions on an article you must assign an Editor.</small>
+                            <small>Before you can perform actions on an article you must be assigned as a Senior Editor.</small>
                         </div>
                     {% endif %}
                 {% else %}

--- a/src/templates/admin/review/unassigned_article.html
+++ b/src/templates/admin/review/unassigned_article.html
@@ -15,6 +15,7 @@
 
 {% block body %}
     {% user_has_role request 'editor' as is_editor %}
+    {% user_has_role request 'section-editor' as is_section_editor %}
     <div class="large-7 columns">
         <div class="box">
             <div class="title-area">
@@ -204,7 +205,7 @@
     </div>
 
     <div class="large-5 columns">
-        {% if is_editor or request.user in section_editors and request.user not in editors %}
+        {% if is_editor or request.user in article.editor_list %}
         <div class="box">
             <div class="title-area">
                 <h2>Editors</h2>
@@ -215,14 +216,18 @@
                         <th>Name</th>
                         <th>Email</th>
                         <th>Type</th>
-                        <th></th>
+                        {% if is_editor %}
+                            <th></th>
+                        {% endif %}
                     </tr>
                     {% for assignment in article.editors %}
                         <tr>
                             <td>{{ assignment.editor.full_name }}</td>
                             <td>{{ assignment.editor.email }}</td>
                             <td>{{ assignment.editor_type|capfirst }}</td>
-                            <td><a href="{% url 'review_unassign_editor' article.id assignment.editor.id %}">Remove</a>
+                            {% if is_editor %}
+                                <td><a href="{% url 'review_unassign_editor' article.id assignment.editor.id %}">Remove</a>
+                            {% endif %}
                             </td>
                         </tr>
                         {% empty %}
@@ -234,6 +239,7 @@
             </div>
         </div>
 
+        {% if is_editor %}
         <div class="box">
             <div class="title-area">
                 <h2>Add Editors</h2>
@@ -284,6 +290,7 @@
             </div>
         </div>
         {% endif %}
+        {% endif %}
         <div class="box">
             <div class="title-area">
                 <h2>Actions</h2>
@@ -300,10 +307,12 @@
                             <li>
                                 <a href="{% url 'review_move_to_review' article.pk %}?return={% url 'review_in_review' article.pk %}"><i
                                         class="fa fa-check action-icon">&nbsp;</i>Move to Review</a></li>
-                            <li><a href="{% url 'review_decision' article.id 'accept' %}"><i
-                                    class="fa fa-check-circle action-icon">&nbsp;</i>Accept Article</a></li>
-                            <li><a href="{% url 'review_decision' article.id 'decline' %}"><i
-                                    class="fa fa-minus-circle action-icon">&nbsp;</i>Decline Article</a></li>
+                            {% if is_editor or is_section_editor and not journal_settings.general.draft_decisions %}
+                                <li><a href="{% url 'review_decision' article.id 'accept' %}"><i
+                                        class="fa fa-check-circle action-icon">&nbsp;</i>Accept Article</a></li>
+                                <li><a href="{% url 'review_decision' article.id 'decline' %}"><i
+                                        class="fa fa-minus-circle action-icon">&nbsp;</i>Decline Article</a></li>
+                            {% endif %}
                         </ul>
                     {% else %}
                         <div class="bs-callout bs-callout-info">

--- a/src/templates/admin/review/unassigned_article.html
+++ b/src/templates/admin/review/unassigned_article.html
@@ -255,7 +255,9 @@
                             <td>{{ account_role.user.email }}</td>
                             <td>Editor</td>
                             <td>
-                                <a href="{% url 'review_assign_editor' article.pk account_role.user.id 'editor' %}?return={% url 'review_unassigned_article' article.pk %}">Add</a>
+                                <a href="{% url 'review_assign_editor' article.pk account_role.user.id 'editor' %}?return={% url 'review_unassigned_article' article.pk %}">
+                                    Add{% if account_role.user == request.user %} Self{% endif %}
+                                </a>
                             </td>
                         </tr>
                     {% endfor %}

--- a/src/utils/install/journal_defaults.json
+++ b/src/utils/install/journal_defaults.json
@@ -1693,6 +1693,25 @@
             "name": "general"
         },
         "setting": {
+            "description": "If enabled, Articles must be assigned at least one Senior Editor to review.",
+            "is_translatable": false,
+            "name": "required_senior_editor",
+            "pretty_name": "Required Senior Editor",
+            "type": "boolean"
+        },
+        "value": {
+            "default": ""
+        },
+        "editable_by": [
+            "editor",
+            "journal-manager"
+        ]
+    },
+    {
+        "group": {
+            "name": "general"
+        },
+        "setting": {
             "description": "If enabled, reviewers will be able to save the progress in a peer-review and come back later to complete it (Only recommended journals using custom review forms that are particularly long)",
             "is_translatable": false,
             "name": "enable_save_review_progress",


### PR DESCRIPTION
## Problem / Objective

As part of adjusting roles and specific workflows for TGDK, the creation of a new option 'RequiredSeniorEditor' is proposed, configurable on the platform, which enables the requirement of assigning at least one user with the role of 'editor' as responsible for the editorial process of the article (like a senior editor).


## Solution

For this, the following features were implemented:
- Boolean configuration `required_senior_editor`, set by default to `False`.
- Management of accesses and available views for editors and section editors in the article assignment template `unassigned_article`.html when the above option is activated:
  - An `Editor` cannot assign `Section Editors` to an article until they are assigned first.
  - An `Editor` cannot unassign `Section Editors` from an article until they are assigned first.
  - An `Editor` cannot make a decision on the article until they are assigned first.
  - All `Editors` can view unassigned or assigned articles, but only the designated `Editor` can take actions.

