### PR TITLE
Fix Some Draft Decisions Options

### DIFF
--- a/src/core/views.py
+++ b/src/core/views.py
@@ -586,6 +586,7 @@ def dashboard(request):
     section_editor_articles = review_models.EditorAssignment.objects.filter(editor=request.user,
                                                                             editor_type='section-editor',
                                                                             article__journal=request.journal)
+    editor_draft_decisions = review_models.DecisionDraft.objects.filter(editor=request.user, editor_decision__isnull=True)
 
     # TODO: Move most of this to model logic.
     context = {
@@ -614,6 +615,7 @@ def dashboard(request):
         'is_author': request.user.is_author(request),
         'is_reviewer': request.user.is_reviewer(request),
         'section_editor_articles': section_editor_articles,
+        'editor_draft_decisions': editor_draft_decisions,
         'active_submission_count': submission_models.Article.objects.filter(
             owner=request.user,
             journal=request.journal).exclude(

--- a/src/review/views.py
+++ b/src/review/views.py
@@ -2292,6 +2292,12 @@ def draft_decision(request, article_id):
     message_to_editor = logic.get_draft_email_message(request, article)
     editors = request.journal.editors()
 
+    required_senior_editor = setting_handler.get_setting(
+        'general', 'required_senior_editor', request.journal
+    ).value
+    if required_senior_editor:
+        editors = editors.filter(id__in=[editor.pk for editor in article.editor_list()])
+
     form = forms.DraftDecisionForm(
         message_to_editor=message_to_editor,
         editors=editors,

--- a/src/templates/admin/core/dashboard.html
+++ b/src/templates/admin/core/dashboard.html
@@ -163,6 +163,48 @@
             {% endif %}
         {% endfor %}
 
+        {% if journal_settings.general.draft_decisions and is_editor %}
+            <div class="large-12 columns end">
+                <div class="box">
+                    <div class="title-area">
+                        <h2>Draft Decisions Pending</h2>
+                    </div>
+                    <div class="content">
+                        <table class="scroll">
+                            <thead>
+                            <tr>
+                                <th>ID</th>
+                                <th>Article</th>
+                                <th>Section Editor</th>
+                                <th>Drafted Date</th>
+                                <th>Draft Decision</th>
+                                <th>Actions</th>
+                            </tr>
+                            </thead>
+                            {% for draft in editor_draft_decisions %}
+                                <tr>
+                                    <td>{{ draft.article.pk }}</td>
+                                    <td>
+                                        <a href="{{ draft.article.current_workflow_element_url }}">{{ draft.article.safe_title }}</a>
+                                    </td>
+                                    <td>{{ draft.section_editor }}</td>
+                                    <td>{{ draft.drafted }}</td>
+                                    <td>{{ draft.decision|capfirst }}</td>
+                                    <td>
+                                        <a class="small button" href="{% url 'review_edit_draft_decision' draft.article.pk draft.id %}">Draft Decisions</a>
+                                    </td>
+                                    
+                                </tr>
+                                {% empty %}
+                                <tr>
+                                    <td colspan="4">No Draft Decision Requested</td>
+                                </tr>
+                            {% endfor %}
+                        </table>
+                    </div>
+                </div>
+            </div>
+        {% endif %}
 
         {% user_has_role request 'section-editor' as sectioneditor %}
         {% if sectioneditor %}


### PR DESCRIPTION
## Problem / Objective
Some problems and errors arise in the assignment flow when the `draft_decisions` option is active.

## Solution
The following implementations are added to address the above:
- A dashboard is added so that `Editors` can more easily access the draft decisions assigned to them.
- Logic is added that prioritizes `Editors` already assigned to the article in the choice of the editor who should approve the draft when the `required_senior_editor` option is active (in this scenario, there should always be someone fulfilling the role of Senior Editor).