### PR TITLE
Fix selectedAccounts selector field in dual_list_js

### DIFF
--- a/src/templates/admin/elements/dual_listbox/dual_listbox_js.html
+++ b/src/templates/admin/elements/dual_listbox/dual_listbox_js.html
@@ -6,7 +6,7 @@
         $('#selectedMembers tbody tr').each(function() {
             selectedIds.push($(this).find('td.id-column').text());
         });
-        $('#selectedMembers').val(selectedIds.join(','));
+        $('#selectedAccounts').val(selectedIds.join(','));
     }
 
     function setSelectedRowHtml(row) {


### PR DESCRIPTION
## Problem / Objective
Fix selectedAccounts selector field in dual_list_js when adding accounts with conflicts of interest.
![image](https://github.com/SSanchez7/janeway/assets/63082386/ff988b79-ef02-4650-85ab-eb1a206e38b3)

Related PR https://github.com/SSanchez7/janeway/pull/9

## Solution
Change `selectedMembers` by `selectedAccounts` id in `dual_listbox_js.html/updateSelectedAccounts` 