### PR TITLE
Fix Add Editor bug in CustomEditorAssignment view

### DIFF
--- a/src/templates/admin/review/add_editor_assignment.html
+++ b/src/templates/admin/review/add_editor_assignment.html
@@ -70,7 +70,7 @@
                             {% if journal_settings.general.enable_suggested_editors or not editor in suggested_editors %}
                             <tr {% if journal_settings.general.enable_competing_interest_selections and editor.has_conflict %}style="color: #b9b9b9;"{% endif %}>
                                 <td>
-                                    <input type="radio" name="editor" value="{{ reviewer.id }}"
+                                    <input type="radio" name="editor" value="{{ editor.id }}"
                                     {% if editor.id == form.cleaned_data.editor.pk %}checked=True{% endif %}
                                     {% if journal_settings.general.enable_competing_interest_selections and editor.has_conflict %}disabled{% endif %}
                                     >
@@ -100,7 +100,7 @@
                             {% if not journal_settings.general.enable_suggested_editors or not editor in suggested_editors %}
                             <tr {% if journal_settings.general.enable_competing_interest_selections and editor.has_conflict %}style="color: #b9b9b9;"{% endif %}>
                                 <td>
-                                    <input type="radio" name="editor" value="{{ reviewer.id }}"
+                                    <input type="radio" name="editor" value="{{ editor.id }}"
                                     {% if editor.id == form.cleaned_data.editor.pk %}checked=True{% endif %}
                                     {% if journal_settings.general.enable_competing_interest_selections and editor.has_conflict %}disabled{% endif %}
                                     >


### PR DESCRIPTION
## Problem / Objective
Editor is selected and user is added (without invitation) but a message still appears that there is a missing field to complete.

![image](https://github.com/SSanchez7/janeway/assets/63082386/ed06177c-e4c9-4844-a266-a7eb48cd6fd1)

## Solution
replace `reviewer` instances by `editor` in `add_editor_assignment.html` template