### PR TITLE
Fix Access Link Review when should be Disabled

### DIFF
--- a/src/templates/admin/elements/article_jump.html
+++ b/src/templates/admin/elements/article_jump.html
@@ -8,7 +8,8 @@
         <a class="button" href="{% url 'review_unassigned_article' article.pk %}">Editor Assignment</a>
         {% for element in article.distinct_workflow_elements %}
             <a class="button{% if element.element_name == 'review' and article.stage == 'Unassigned' %} disabled{% endif %}"
-               href="{% url element.jump_url article.pk %}">{{ element.element_name|capfirst }}</a>
+            {% if element.element_name != 'review' or article.stage != 'Unassigned' %}href="{% url element.jump_url article.pk %}"{% endif %}
+            >{{ element.element_name|capfirst }}</a>
         {% endfor %}
         <button class="button" type="button" data-toggle="more-dropdown">Logs, Documents and More</button>
 


### PR DESCRIPTION
## Problem / Objective
When clicking on the link that sends to the review stage, it redirects correctly even though it apparently should be disabled

![image](https://github.com/SSanchez7/janeway/assets/63082386/00d7a2b7-ca9f-4cab-a41d-c36afce1fdbf)

## Solution
Based on https://css-tricks.com/how-to-disable-links/

It is not a good idea to disable a link, after all a disabled link is nothing more than plain text. However, following the most direct recommendation, the href is disabled so that it does not redirect anywhere

```jinja
{% if is_disabled %}
    href=...
{% endif %}
```