### PR TITLE
fix add_editor_assignment breadcrumbs to redirect correctly to unassi…

### DIFF
--- a/src/templates/admin/review/add_editor_assignment.html
+++ b/src/templates/admin/review/add_editor_assignment.html
@@ -6,7 +6,8 @@
 
 {% block breadcrumbs %}
     {{ block.super }}
-    {% include "elements/breadcrumbs/review_base.html" %}
+    {% include "elements/breadcrumbs/unassigned_base.html" %}
+    {% if article %}<li><a href="{% url 'review_unassigned_article' article.pk %}">{{ article.safe_title }}</a></li>{% endif %}
     <li>Add Editor Assignment</li>
 {% endblock breadcrumbs %}
 


### PR DESCRIPTION
## Problem / Objective
The links in the breadcrumbs of the view to add editor assignments were incorrectly redirecting to the article under review

related to https://github.com/SSanchez7/janeway/pull/7

## Solution
the view breadcrumbs were updated