### PR TITLE
Add Accepted Articles section in Article Back Content (Archive)

### DIFF
--- a/src/journal/views.py
+++ b/src/journal/views.py
@@ -1759,10 +1759,20 @@ def manage_archive(request):
         '-date_declined'
     )
 
+    accepted_articles = submission_models.Article.objects.filter(
+        journal=request.journal,
+        stage__in=[
+            submission_models.STAGE_ACCEPTED,
+        ],
+    ).order_by(
+        '-date_accepted'
+    )
+
     template = 'journal/manage/archive.html'
     context = {
         'published_articles': published_articles,
         'rejected_articles': rejected_articles,
+        'accepted_articles': accepted_articles,
     }
 
     return render(request, template, context)

--- a/src/templates/admin/journal/manage/archive.html
+++ b/src/templates/admin/journal/manage/archive.html
@@ -17,25 +17,25 @@
     <div class="large-6 columns">
         <div class="box">
             <div class="title-area">
-                <h2>Published Articles</h2>
+                <h2>Accepted Articles</h2>
             </div>
             <div class="content">
                 <table class="small article_list scroll">
                     <thead>
                     <tr>
-                        <td>{{ ID }}</td>
+                        <td>ID</td>
                         <td>Title</td>
-                        <td>Published</td>
+                        <td>Accepted</td>
                         <td>Identifier</td>
                     </tr>
                     </thead>
 
                     <tbody>
-                    {% for article in published_articles %}
+                        {% for article in accepted_articles %}
                         <tr>
                             <td>{{ article.pk }}</td>
                             <td><a href="{% url 'manage_archive_article' article.pk %}">{{ article.safe_title }}</a></td>
-                            <td>{{ article.date_published }}</td>
+                            <td>{{ article.date_accepted }}</td>
                             <td>{{ article.identifier }}</td>
                         </tr>
                     {% endfor %}
@@ -67,6 +67,37 @@
                             <td>{{ article.pk }}</td>
                             <td><a href="{% url 'manage_archive_article' article.pk %}">{{ article.safe_title }}</a></td>
                             <td>{{ article.date_declined|default_if_none:"Archived" }}</td>
+                            <td>{{ article.identifier }}</td>
+                        </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+
+    <div class="large-12 columns">
+        <div class="box">
+            <div class="title-area">
+                <h2>Published Articles</h2>
+            </div>
+            <div class="content">
+                <table class="small article_list scroll">
+                    <thead>
+                    <tr>
+                        <td>{{ ID }}</td>
+                        <td>Title</td>
+                        <td>Published</td>
+                        <td>Identifier</td>
+                    </tr>
+                    </thead>
+
+                    <tbody>
+                    {% for article in published_articles %}
+                        <tr>
+                            <td>{{ article.pk }}</td>
+                            <td><a href="{% url 'manage_archive_article' article.pk %}">{{ article.safe_title }}</a></td>
+                            <td>{{ article.date_published }}</td>
                             <td>{{ article.identifier }}</td>
                         </tr>
                     {% endfor %}


### PR DESCRIPTION
## Problem / Objective
In a Review-only workflow setup, when articles are accepted (final state) they are not accessible from the “repository”. The article exists, but there is no way from the interface to reach it

## Solution
A new table is added to display the articles accepted in the review process, but that have not yet been published

<img width="1446" alt="image" src="https://github.com/SSanchez7/janeway/assets/63082386/e6d7ef9b-85ee-43ad-b587-c1a4bf1d47ba">
