### PR TITLE
Fix Article Stage for accepted Draft Decisions

### DIFF
--- a/src/review/logic.py
+++ b/src/review/logic.py
@@ -817,7 +817,7 @@ def handle_decision_action(article, draft, request):
     }
 
     if draft.decision == ED.ACCEPT.value:
-        article.accept_article(stage=submission_models.STAGE_EDITOR_COPYEDITING)
+        article.accept_article(stage=submission_models.STAGE_ACCEPTED)
         event_logic.Events.raise_event(
             event_logic.Events.ON_ARTICLE_ACCEPTED,
             task_object=article,


### PR DESCRIPTION
## Problem / Objective
By having the draft_decisions option activated and limiting the workflows only to the review process of an article, accepting a draft decision that accepts the article should change its stage to `Accepted`, but changes to `Editor Copyediting`.

## Solution
This is caused by directly entering the stage as `STAGE_EDITOR_COPYEDITING` in `manage_draft`.
```python
article.accept_article(stage=submission_models.STAGE_EDITOR_COPYEDITING)
```

It is validated that this should be `STAGE_ACCEPTED`, and then, if the workflow has Copyediting step, change automatically , but the first stage must be `Accepted`
