### PR TITLE
Manage Editor Assignment Requests

### DIFF
--- a/src/events/logic.py
+++ b/src/events/logic.py
@@ -26,6 +26,7 @@ class Events:
     # kwargs: editor_assignment, request, email_data, acknowledgement (true), skip (boolean)
     # raised when an editor decides to notify to another editor with a custom message or skipped the email
     ON_EDITOR_REQUESTED_NOTIFICATION = 'on_editor_requested_notification'
+    ON_EDITOR_REQUEST_REMINDED = 'on_editor_request_reminded'
     # kwargs: editor_assignment, request, accepted (boolean)
     # raised when an editor accepts or declines to assignment request
     ON_EDITOR_ASSIGNMENT_ACCEPTED = 'on_editor_assignment_accepted'

--- a/src/events/logic.py
+++ b/src/events/logic.py
@@ -27,6 +27,9 @@ class Events:
     # raised when an editor decides to notify to another editor with a custom message or skipped the email
     ON_EDITOR_REQUESTED_NOTIFICATION = 'on_editor_requested_notification'
     ON_EDITOR_REQUEST_REMINDED = 'on_editor_request_reminded'
+    # kwargs: review_assignment, request, user_message_content, skip (boolean)
+    # raised when an editor decides to notify the reviewer of a assignment withdrawl (or skip the notification)
+    ON_EDITOR_REQUEST_WITHDRAWL = 'on_editor_request_withdrawl'
     # kwargs: editor_assignment, request, accepted (boolean)
     # raised when an editor accepts or declines to assignment request
     ON_EDITOR_ASSIGNMENT_ACCEPTED = 'on_editor_assignment_accepted'

--- a/src/events/registration.py
+++ b/src/events/registration.py
@@ -23,6 +23,8 @@ event_logic.Events.register_for_event(event_logic.Events.ON_EDITOR_MANUALLY_ASSI
                                       transactional_emails.send_editor_manually_assigned)
 event_logic.Events.register_for_event(event_logic.Events.ON_EDITOR_REQUESTED_NOTIFICATION,
                                       transactional_emails.send_editor_assignment_requested)
+event_logic.Events.register_for_event(event_logic.Events.ON_EDITOR_REQUEST_REMINDED,
+                                      transactional_emails.send_editor_assignment_reminder)
 event_logic.Events.register_for_event(event_logic.Events.ON_ARTICLE_UNASSIGNED,
                                       transactional_emails.send_editor_unassigned_notice)
 event_logic.Events.register_for_event(event_logic.Events.ON_EDITOR_ASSIGNMENT_ACCEPTED,

--- a/src/events/registration.py
+++ b/src/events/registration.py
@@ -25,6 +25,8 @@ event_logic.Events.register_for_event(event_logic.Events.ON_EDITOR_REQUESTED_NOT
                                       transactional_emails.send_editor_assignment_requested)
 event_logic.Events.register_for_event(event_logic.Events.ON_EDITOR_REQUEST_REMINDED,
                                       transactional_emails.send_editor_assignment_reminder)
+event_logic.Events.register_for_event(event_logic.Events.ON_EDITOR_REQUEST_WITHDRAWL,
+                                      transactional_emails.send_editor_assignment_withdrawl)
 event_logic.Events.register_for_event(event_logic.Events.ON_ARTICLE_UNASSIGNED,
                                       transactional_emails.send_editor_unassigned_notice)
 event_logic.Events.register_for_event(event_logic.Events.ON_EDITOR_ASSIGNMENT_ACCEPTED,

--- a/src/review/forms.py
+++ b/src/review/forms.py
@@ -194,6 +194,19 @@ class EditorAssignmentForm(core_forms.ConfirmableIfErrorsForm):
         return editor_assignment
 
 
+class EditEditorAssignmentForm(forms.ModelForm):
+    class Meta:
+        model = models.EditorAssignmentRequest
+        fields = ('date_due',)
+        widgets = {
+            'date_due': HTMLDateInput,
+        }
+
+    def __init__(self, *args, **kwargs):
+        self.journal = kwargs.pop('journal', None)
+        super(EditEditorAssignmentForm, self).__init__(*args, **kwargs)
+
+
 class BulkReviewAssignmentForm(forms.ModelForm):
     template = forms.CharField(
         widget=TinyMCE,

--- a/src/review/urls.py
+++ b/src/review/urls.py
@@ -109,6 +109,7 @@ urlpatterns = [
     re_path(r'^requests/editor/(?P<assignment_id>\d+)/decline/$', views.decline_editor_assignment_request, name='decline_editor_assignment'),
     re_path(r'^requests/editor/(?P<assignment_id>\d+)/delete/$', views.delete_editor_assignment_request, name='delete_editor_assignment'),
     re_path(r'^requests/editor/(?P<assignment_id>\d+)/edit/$', views.edit_editor_assignment_request, name='edit_editor_assignment'),
+    re_path(r'^requests/editor/(?P<assignment_id>\d+)/reminder/$', views.remind_editor_assignment_request, name='remind_editor_assignment'),
 
     re_path(r'^author/(?P<article_id>\d+)/$', views.author_view_reviews, name='review_author_view'),
 

--- a/src/review/urls.py
+++ b/src/review/urls.py
@@ -108,6 +108,7 @@ urlpatterns = [
     re_path(r'^requests/editor/(?P<assignment_id>\d+)/accept/$', views.accept_editor_assignment_request, name='accept_editor_assignment'),
     re_path(r'^requests/editor/(?P<assignment_id>\d+)/decline/$', views.decline_editor_assignment_request, name='decline_editor_assignment'),
     re_path(r'^requests/editor/(?P<assignment_id>\d+)/delete/$', views.delete_editor_assignment_request, name='delete_editor_assignment'),
+    re_path(r'^requests/editor/(?P<assignment_id>\d+)/edit/$', views.edit_editor_assignment_request, name='edit_editor_assignment'),
 
     re_path(r'^author/(?P<article_id>\d+)/$', views.author_view_reviews, name='review_author_view'),
 

--- a/src/review/urls.py
+++ b/src/review/urls.py
@@ -109,6 +109,7 @@ urlpatterns = [
     re_path(r'^requests/editor/(?P<assignment_id>\d+)/decline/$', views.decline_editor_assignment_request, name='decline_editor_assignment'),
     re_path(r'^requests/editor/(?P<assignment_id>\d+)/delete/$', views.delete_editor_assignment_request, name='delete_editor_assignment'),
     re_path(r'^requests/editor/(?P<assignment_id>\d+)/edit/$', views.edit_editor_assignment_request, name='edit_editor_assignment'),
+    re_path(r'^requests/editor/(?P<assignment_id>\d+)/withdraw/$', views.withdraw_editor_assignment_request, name='withdraw_editor_assignment'),
     re_path(r'^requests/editor/(?P<assignment_id>\d+)/reminder/$', views.remind_editor_assignment_request, name='remind_editor_assignment'),
 
     re_path(r'^author/(?P<article_id>\d+)/$', views.author_view_reviews, name='review_author_view'),

--- a/src/templates/admin/elements/review/editor_request_dropdown.html
+++ b/src/templates/admin/elements/review/editor_request_dropdown.html
@@ -18,5 +18,9 @@
                 </a>
             </li>
         {% endif %}
+        <li>
+            <a href="{% url 'withdraw_editor_assignment' assignment.id %}"><i
+                    class="fa fa-backward action-icon">&nbsp;</i>Withdraw</a>
+        </li>
     </ul>
 </div>

--- a/src/templates/admin/elements/review/editor_request_dropdown.html
+++ b/src/templates/admin/elements/review/editor_request_dropdown.html
@@ -1,0 +1,11 @@
+<div class="button-group" style="margin-bottom: 0;">
+    <a class="button" data-toggle="review-dropdown-{{ review.pk }}" style="padding: 0.4rem"><i class="fa fa-cog"></i></a>
+</div>
+<div class="dropdown-pane {{ dropdown }}"
+     id="review-dropdown-{{ review.pk }}"
+     data-dropdown data-close-on-click="true"
+     data-alignment="bottom"
+     >
+    <ul class="menu vertical actions">
+    </ul>
+</div>

--- a/src/templates/admin/elements/review/editor_request_dropdown.html
+++ b/src/templates/admin/elements/review/editor_request_dropdown.html
@@ -11,5 +11,12 @@
             <a href="{% url 'edit_editor_assignment' assignment.pk %}"><i
                     class="fa fa-pencil action-icon">&nbsp;</i>Edit</a>
         </li>
+        {% if not assignment.is_complete %}
+            <li>
+                <a href="{% url 'remind_editor_assignment' assignment.pk %}">
+                    <i class="fa fa-clock-o action-icon"></i> Send Reminder
+                </a>
+            </li>
+        {% endif %}
     </ul>
 </div>

--- a/src/templates/admin/elements/review/editor_request_dropdown.html
+++ b/src/templates/admin/elements/review/editor_request_dropdown.html
@@ -7,5 +7,9 @@
      data-alignment="bottom"
      >
     <ul class="menu vertical actions">
+        <li>
+            <a href="{% url 'edit_editor_assignment' assignment.pk %}"><i
+                    class="fa fa-pencil action-icon">&nbsp;</i>Edit</a>
+        </li>
     </ul>
 </div>

--- a/src/templates/admin/review/edit_editor_assignment.html
+++ b/src/templates/admin/review/edit_editor_assignment.html
@@ -1,0 +1,41 @@
+{% extends "admin/core/base.html" %}
+{% load foundation %}
+
+{% block title %}Edit Editor Assignment Request{% endblock title %}
+{% block title-section %}Edit Editor Assignment Request{% endblock %}
+{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
+
+{% block breadcrumbs %}
+    {{ block.super }}
+    {% include "elements/breadcrumbs/unassigned_base.html" %}
+    {% if article %}<li><a href="{% url 'review_unassigned_article' article.pk %}">{{ article.safe_title }}</a></li>{% endif %}
+    <li>Edit Editor Assignment Request</li>
+{% endblock breadcrumbs %}
+
+{% block body %}
+    <div class="large-12 columns">
+        <div class="box">
+            <div class="title-area">
+                <h2>Set Options</h2>
+            </div>
+            <div class="content">
+                <p>Once the request is accepted you can no longer change the review type or the form.</p>
+                <div class="row expanded">
+                    <form method="POST">
+                        {% csrf_token %}
+                      <div class="row expanded">
+                        <div class="large-4 columns">{{ form.date_due|foundation }}</div>
+                      </div>
+                      <div class="row expanded">
+                        <div class="large-12 columns">
+                            <button class="button success" name="update" type="submit">Update Review</button>
+                            <a href="{% url 'review_unassigned_article' article.pk %}" class="button alert"
+                               type="submit">Cancel</a>
+                        </div>
+                      </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock body %}

--- a/src/templates/admin/review/notify_remind_editor.html
+++ b/src/templates/admin/review/notify_remind_editor.html
@@ -1,0 +1,49 @@
+{% extends "admin/core/base.html" %}
+{% load static %}
+{% load settings %}
+
+
+{% block title %}Editor Assignment Reminders{% endblock title %}
+{% block title-section %}Editor Assignment Reminders{% endblock %}
+{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
+
+{% block css %}
+    <link href="{% static "common/css/jquery-te-1.4.0.css" %}" rel="stylesheet">
+{% endblock %}
+
+{% block breadcrumbs %}
+    {{ block.super }}
+    {% include "elements/breadcrumbs/unassigned_base.html" %}
+    {% if article %}<li><a href="{% url 'review_unassigned_article' article.pk %}">{{ article.safe_title }}</a></li>{% endif %}
+    <li>Send Editor Assignment Reminder</li>
+{% endblock breadcrumbs %}
+
+{% block body %}
+
+    <div class="large-12 columns">
+        <div class="box">
+            <div class="title-area">
+                <h2>Send Request Reminder</h2>
+            </div>
+            <div class="content">
+                <p>As this editor assignment has not been accepted, you can send a reminder to the editor asking them to undertake the request.</p>
+                <div class="card">
+                    <div class="card-divider">
+                        <h4>To {{ assignment.editor.full_name }}</h4>
+                        <h5>From {{ request.user.full_name }}</h5>
+                    </div>
+                </div>
+                {% include "admin/elements/email_form.html" with form=form skip=0 %}
+            </div>
+        </div>
+    </div>
+    </div>
+
+{% endblock body %}
+
+{% block js %}
+    {{ block.super}}
+    <link rel="stylesheet" href="https://code.jquery.com/ui/1.11.0/themes/smoothness/jquery-ui.css">
+    {{ form.media.js }}
+
+{% endblock js %}

--- a/src/templates/admin/review/unassigned_article.html
+++ b/src/templates/admin/review/unassigned_article.html
@@ -297,36 +297,51 @@
                             {% endif %}
                             </td>
                         </tr>
-                    {% endfor %}
-                    {% if journal_settings.general.enable_invite_editor and editor_can_access %}
-                    {% for assignment in requested_editors %}
-                    <tr style="color: #b9b9b9;">
-                        <td>{{ assignment.editor.full_name }}</td>
-                        <td>{{ assignment.editor.email }}</td>
-                        <td>
-                            {{ assignment.editor_type|capfirst }}
-                        </td>
-                        <td>
-                            <span data-tooltip class="top" tabindex="2" title="Date due: {{ assignment.date_due|date:"Y-m-d" }}">
-                                Requested
-                            </span>
-                        </td>
-                        {% if editor_can_access %}
-                        <td>
-                            <a href="{% url 'delete_editor_assignment' assignment.id %}">Cancel</a>
-                        </td>
-                        {% endif %}
-                    </tr>
-                    {% endfor %}
-                    {% endif %}
-                    {% if not article.editors and not requested_editors %}
+                    {% empty %}
                         <tr>
                             <td colspan="4">No users assigned</td>
                         </tr>
-                    {% endif %}
+                    {% endfor %}
                 </table>
             </div>
         </div>
+
+        {% if journal_settings.general.enable_invite_editor and requested_editors and editor_can_access %}
+        <div class="box">
+            <div class="title-area">
+                <h2>Editor Requests</h2>
+            </div>
+            <div class="content">
+                <table class="scroll small" id="unassigned">
+                    <tr>
+                        <th>Name</th>
+                        <th>Email</th>
+                        <th>Type</th>
+                        <th>Date Due</th>
+                        <th></th>
+                    </tr>
+                    {% for assignment in requested_editors %}
+                    <tr>
+                        <td>
+                            {{ assignment.editor.full_name }}&nbsp;
+                            <span data-tooltip title="Email editor."><a
+                                onclick="return popitup('{% url 'send_user_email_article' assignment.editor.id article.pk %}')"><span
+                                class="fa fa-envelope">&nbsp;</span></a></span>
+                        </td>
+                        <td>{{ assignment.editor.email }}</td>
+                        <td>{{ assignment.editor_type|capfirst }}</td>
+                        <td>{{ assignment.date_due|date:"Y-m-d" }}</td>
+                        <td>{% include "admin/elements/review/editor_request_dropdown.html" %}</td>
+                    </tr>
+                    {% empty %}
+                        <tr>
+                            <td colspan="4">No users requested</td>
+                        </tr>
+                    {% endfor %}
+                </table>
+            </div>
+        </div>
+        {% endif %}
 
         {% if is_editor %}
         {% if journal_settings.general.required_senior_editor %}

--- a/src/templates/admin/review/withdraw_editor_assignment.html
+++ b/src/templates/admin/review/withdraw_editor_assignment.html
@@ -1,0 +1,44 @@
+{% extends "admin/core/base.html" %}
+{% load settings %}
+
+{% block title %}Withdraw Editor Assignment Request{% endblock title %}
+{% block title-section %}Withdraw Editor Assignment Request{% endblock %}
+{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
+
+{% block breadcrumbs %}
+    {{ block.super }}
+    {% include "elements/breadcrumbs/unassigned_base.html" %}
+    {% if article %}<li><a href="{% url 'review_unassigned_article' article.pk %}">{{ article.safe_title }}</a></li>{% endif %}
+    <li>Withdraw Editor Assignment Request</li>
+{% endblock breadcrumbs %}
+
+{% block body %}
+
+    <div class="large-12 columns">
+        <div class="box">
+            <div class="content">
+                <p>You are withdrawing an editor assignment by {{ assignment.editor.full_name }} from {{ article.safe_title }}. It was due
+                    on {{ assignment.date_due }}.</p>
+                <p>If you select Skip, the editor will not be notified.</p>
+
+                <div class="card">
+                    <div class="card-divider">
+                        <h4>To {{ assignment.editor.full_name }}</h4>
+                        <h5>From {{ request.user.full_name }}</h5>
+                    </div>
+                    {% url 'review_unassigned_article' article.pk as cancel_url %}
+                    {% include 'admin/elements/email_form.html' with form=form skip=1 cancel_url=cancel_url %}
+                </div>
+            </div>
+        </div>
+
+    </div>
+
+{% endblock body %}
+
+{% block js %}
+    {{ block.super}}
+    <link rel="stylesheet" href="https://code.jquery.com/ui/1.11.0/themes/smoothness/jquery-ui.css">
+    {{ form.media.js }}
+
+{% endblock js %}

--- a/src/utils/install/journal_defaults.json
+++ b/src/utils/install/journal_defaults.json
@@ -268,6 +268,25 @@
             "name": "email"
         },
         "setting": {
+            "description": "Email sent to editors when an editor assignment request is withdrawn.",
+            "is_translatable": true,
+            "name": "editor_assignment_withdrawl",
+            "pretty_name": "Editor Assignment Withdrawl",
+            "type": "rich-text"
+        },
+        "value": {
+            "default": "<p>Dear {{ editor_assignment.editor.full_name }},</p><p>We are writing to let you know that the editor assignment request for \"{{ article.safe_title }}\" in {{ article.journal.name }} has been cancelled.</p><p>We thank you for your time but your participation is no longer required.</p><p>Regards,</p>{{ request.user.signature|safe }}"
+        },
+        "editable_by": [
+            "editor",
+            "journal-manager"
+        ]
+    },
+    {
+        "group": {
+            "name": "email"
+        },
+        "setting": {
             "description": "Email sent to authors when they have submitted an article.",
             "is_translatable": true,
             "name": "submission_acknowledgement",
@@ -2914,6 +2933,25 @@
             "is_translatable": true,
             "description": "Subject for Email sent to editors to remind an editor assignment request.",
             "name": "subject_editor_assignment_reminder"
+        },
+        "group": {
+            "name": "email_subject"
+        },
+        "editable_by": [
+            "editor",
+            "journal-manager"
+        ]
+    },
+    {
+        "value": {
+            "default": "Editor Assignment Request Withdrawn"
+        },
+        "setting": {
+            "type": "char",
+            "pretty_name": "Subject Editor Assignment Withdrawl",
+            "is_translatable": true,
+            "description": "Subject for Email sent to editors when an editor assignment request is withdrawn.",
+            "name": "subject_editor_assignment_withdrawl"
         },
         "group": {
             "name": "email_subject"

--- a/src/utils/install/journal_defaults.json
+++ b/src/utils/install/journal_defaults.json
@@ -249,6 +249,25 @@
             "name": "email"
         },
         "setting": {
+            "description": "Email to remind editors of a new assignment request.",
+            "is_translatable": true,
+            "name": "editor_assignment_reminder",
+            "pretty_name": "Editor Assignment Reminder",
+            "type": "rich-text"
+        },
+        "value": {
+            "default": "Dear {{ editor_assignment.editor.full_name }},<br/><br/>We recently sent you an email requesting if you can participate in the review of \"{{ article.safe_title }}\" in {{ article.journal.name }}.<br/><br/>We would be most grateful for your time as the feedback from our editors is of the utmost importance to our editorial decision-making processes.<br/><br/>We would appreciate it if you could let us know your decision or decline to participate in the review process <br/><br/>Regards,<br/>{{ request.user.signature|safe }}"
+        },
+        "editable_by": [
+            "editor",
+            "journal-manager"
+        ]
+    },
+    {
+        "group": {
+            "name": "email"
+        },
+        "setting": {
             "description": "Email sent to authors when they have submitted an article.",
             "is_translatable": true,
             "name": "submission_acknowledgement",
@@ -2876,6 +2895,25 @@
             "is_translatable": true,
             "description": "Subject for Email sent to editors to request an editor assignment.",
             "name": "subject_editor_assignment_request"
+        },
+        "group": {
+            "name": "email_subject"
+        },
+        "editable_by": [
+            "editor",
+            "journal-manager"
+        ]
+    },
+    {
+        "value": {
+            "default": "Editor Assignment Request Reminder"
+        },
+        "setting": {
+            "type": "text",
+            "pretty_name": "Subject Editor Assignment Reminder",
+            "is_translatable": true,
+            "description": "Subject for Email sent to editors to remind an editor assignment request.",
+            "name": "subject_editor_assignment_reminder"
         },
         "group": {
             "name": "email_subject"

--- a/src/utils/transactional_emails.py
+++ b/src/utils/transactional_emails.py
@@ -191,7 +191,7 @@ def send_editor_assignment_requested(**kwargs):
 
     log_dict = {'level': 'Info',
                 'action_text': description,
-                'types': 'Review Request',
+                'types': 'Editor Assignment Request',
                 'target': article}
 
     if not skip:
@@ -202,6 +202,39 @@ def send_editor_assignment_requested(**kwargs):
             article=article,
             log_dict=log_dict,
         )
+
+    notify_helpers.send_slack(request, description, ['slack_editors'])
+
+
+def send_editor_assignment_reminder(**kwargs):
+    """
+    This function is called via the event handling framework and it reminds that a editor has been requested.
+    It is wired up in core/urls.py.
+    :param kwargs: a list of kwargs that includes editor_assignment, email_data, skip (boolean) and request
+    :return: None
+    """
+    email_data = kwargs["email_data"]
+    editor_assignment = kwargs['editor_assignment']
+    article = editor_assignment.article
+    request = kwargs['request']
+
+    description = 'An editor assignment request to "{0}" for user {1} was reminded'.format(
+        article.title,
+        editor_assignment.editor.full_name(),
+    )
+
+    log_dict = {'level': 'Info',
+                'action_text': description,
+                'types': 'Editor Assignment Reminder',
+                'target': article}
+
+    core_email.send_email(
+        editor_assignment.editor,
+        email_data,
+        request,
+        article=article,
+        log_dict=log_dict,
+    )
 
     notify_helpers.send_slack(request, description, ['slack_editors'])
 

--- a/src/utils/transactional_emails.py
+++ b/src/utils/transactional_emails.py
@@ -239,6 +239,35 @@ def send_editor_assignment_reminder(**kwargs):
     notify_helpers.send_slack(request, description, ['slack_editors'])
 
 
+def send_editor_assignment_withdrawl(**kwargs):
+    editor_assignment = kwargs['editor_assignment']
+    request = kwargs['request']
+    email_data = kwargs['email_data']
+    article = editor_assignment.article
+    skip = kwargs.get('skip', True)
+
+    description = '{0}\'s editor assignment of "{1}" has been withdrawn by {2}'.format(
+        editor_assignment.editor.full_name(),
+        editor_assignment.article.title,
+        request.user.full_name(),
+    )
+    log_dict = {
+            'level': 'Info', 'action_text': description,
+            'types': 'Editor Assignment Withdrawl', 'target': editor_assignment.article,
+    }
+
+    if not skip:
+        core_email.send_email(
+            editor_assignment.editor,
+            email_data,
+            request,
+            article=article,
+            log_dict=log_dict,
+        )
+
+    notify_helpers.send_slack(request, description, ['slack_editors'])
+
+
 def send_reviewer_requested(**kwargs):
     """
     This function is called via the event handling framework and it notifies that a reviewer has been requested.


### PR DESCRIPTION
## Problem / Objective
Being able to manage editor assignment requests to an article is required to be able to edit deadlines, remember, and cancel pending assignment requests.

## Solution
Updated the `unassigned_article` view to separate completed assignments from pending requests, and added dropdown functionality:
* editing pending editor assignment requests
* reminder for editors of pending assignment requests
* cancellation of pending editor assignment requests

> [!IMPORTANT]
> This PR is related to https://github.com/SSanchez7/janeway/pull/7 where assignment invitations to editors are implemented and assignment requests are configured

![image](https://github.com/SSanchez7/janeway/assets/63082386/4c2aa20a-03a4-4fb6-8062-572351b25b37)
