### PR TITLE
Update Review Decision Section

### DIFF
--- a/src/review/views.py
+++ b/src/review/views.py
@@ -3366,6 +3366,7 @@ def decision_helper(request, article_id):
     reviews = models.ReviewAssignment.objects.filter(
         article=article,
     )
+    review_rounds = models.ReviewRound.objects.filter(article=article)
 
     uncomplete_reviews = reviews.filter(
         article=article,
@@ -3432,6 +3433,7 @@ def decision_helper(request, article_id):
     template = 'admin/review/decision_helper.html'
     context = {
         'article': article,
+        'review_rounds': review_rounds,
         'complete_reviews': complete_reviews,
         'uncomplete_reviews': uncomplete_reviews,
         'decisions': dict(decisions)

--- a/src/templates/admin/elements/review/decision_form_modal.html
+++ b/src/templates/admin/elements/review/decision_form_modal.html
@@ -30,7 +30,7 @@
                     <h2>Comments for the Editor (Won't be shown to the authors)</h2>
                 </div>
                 <div class="content">
-                    <p>{{ review.comments_for_editor|linebreaksbr }}</p>
+                    {{ review.comments_for_editor|safe|linebreaksbr }}
                 </div>
             {% endif %}
         </div>

--- a/src/templates/admin/review/decision_helper.html
+++ b/src/templates/admin/review/decision_helper.html
@@ -14,6 +14,19 @@
 {% endblock breadcrumbs %}
 
 {% block body %}
+<div class="box" style="margin-bottom: 0;" >
+    <ul class="tabs" data-tabs id="round-tabs">
+        {% for round in review_rounds %}
+            <li class="tabs-title {% if forloop.first %} is-active{% endif %}"><a
+                    href="#tab{{ round.round_number }}"
+                    aria-selected="true">Round {{ round.round_number }}</a></li>
+        {% endfor %}
+    </ul>
+</div>
+
+<div class="tabs-content" data-tabs-content="round-tabs" style="background: none;">
+    {% for round in review_rounds %}
+    <div class="tabs-panel{% if forloop.first %} is-active{% endif %}" id="tab{{ round.round_number }}" style="padding:0;">
     <div class="box">
         <div class="row expanded">
             <div class="large-6 columns">
@@ -21,8 +34,10 @@
                 {% user_has_role request 'editor' as editor %}
                 <h2 style="color: #5bc0de;"><span class="fa fa-clipboard"></span> Reviewer Recommendations</h2>
                 <div class="bs-callout bs-callout-info">
-                    {% for decision, counter in decisions.items %}
+                    {% for decision, counter in round.decisions_count.items %}
                     <p><strong>{{ decision|capfirst }}</strong>: {{ counter }}</p>
+                    {% empty %}
+                    No Reviewer Decisions.
                     {% endfor %}
                 </div>
             </div>
@@ -49,25 +64,25 @@
                         {% endif %}
                         {% if not journal_settings.general.draft_decisions or editor %}
                             <a href="{% url 'review_decision' article.id 'accept' %}"
-                               class="button success"><i
+                            class="button success"><i
                                     class="fa fa-check-circle action-icon">&nbsp;</i>Accept
                                 Article</a> Accept Article</a>
                             <a href="#" data-open="newround"
-                               class="button warning"><i
+                            class="button warning"><i
                                     class="fa fa-plus-circle action-icon">&nbsp;</i>New
                                 Review Round
                             </a>
                             <a href="{% url 'review_decision' article.id 'decline' %}"
-                               class="button alert"><i
+                            class="button alert"><i
                                     class="fa fa-minus-circle action-icon">&nbsp;</i>Reject
                                 Article</a>
                             <a href="{% url 'review_request_revisions' article.pk %}"
-                               class="button warning"><i
+                            class="button warning"><i
                                     class="fa fa-inbox action-icon">&nbsp;</i>Request
                                 Revisions</a>
                             {% if journal_settings.general.enable_share_reviews_decision %}
                             <a href="{% url 'editor_share_reviews' article.pk %}"
-                               class="button info"><i
+                            class="button info"><i
                                     class="fa fa-share-square-o action-icon">&nbsp;</i>Share Reviews</a>
                             {% endif %}
                         {% endif %}
@@ -80,9 +95,9 @@
         <div class="row expanded">
             <div class="large-6 columns">
                 <h2 class="success green"><i
-                        class="fa fa-check-square"></i> {{ complete_reviews.count }}
+                        class="fa fa-check-square"></i> {{ round.complete_reviews.count }}
                     completed reviews</h2>
-                {% for review in complete_reviews %}
+                {% for review in round.complete_reviews %}
                     <div class="bs-callout bs-callout-{% if review.for_author_consumption %}success{% else %}warning{% endif %}">
                         <h4>
                             #{{ review.pk }} {{ review.reviewer.full_name }} (Round {{ review.review_round.round_number }})
@@ -103,9 +118,9 @@
                                     <div class="switch tiny pull-right">
                                         <input type="hidden" name="review_id" value="{{ review.pk }}">
                                         <input class="switch-input" type="checkbox" name="visibility"
-                                               id="{{ review.pk }}"
-                                               {% if review.for_author_consumption %}checked="checked"{% endif %}
-                                               onclick="this.form.submit()"
+                                            id="{{ review.pk }}"
+                                            {% if review.for_author_consumption %}checked="checked"{% endif %}
+                                            onclick="this.form.submit()"
                                         >
                                         <label class="switch-paddle" for="{{ review.pk }}">
                                             <span class="switch-active" aria-hidden="true">{% trans 'Yes' %}</span>
@@ -121,9 +136,9 @@
             </div>
             <div class="large-6 columns">
                 <h2 class="danger red"><i
-                        class="fa fa-exclamation-triangle"></i> {{ uncomplete_reviews.count }}
+                        class="fa fa-exclamation-triangle"></i> {{ round.uncomplete_reviews.count }}
                     uncompleted reviews </h2>
-                {% for review in uncomplete_reviews %}
+                {% for review in round.uncomplete_reviews %}
                     <div class="bs-callout {% if review.date_accepted %}bs-callout-warning{% else %}bs-callout-danger{% endif %}">
                         <h4>{{ review.reviewer.full_name }} (Round {{ review.review_round.round_number }})</h4>
                         <p>This review was assigned
@@ -140,6 +155,10 @@
             </div>
         </div>
     </div>
+    </div>
+    {% endfor %}
+</div>
+
 
     {% for review in complete_reviews %}
     {% include "elements/review/decision_form_modal.html" with review=review %}


### PR DESCRIPTION
## Problem / Objective
- Decision Assistant is a bit confusing.
- The reviews displayed correspond to those of all review rounds, which could lead to making an outdated decision if it is not taken into account.

> [!NOTE]
> Review Decisions (Accept / Decline) and Revision Requests are associated with the Article, not with the Review Round.

## Solution
- The template is updated to allow filtering of completed and incomplete reviews and their counts by review round, always displaying the most current one by default.

![image](https://github.com/SSanchez7/janeway/assets/63082386/f42de658-db35-4603-b653-7e3627ac56af)
