### PR TITLE
Add Custom Table Page Length

### DIFF
--- a/src/core/logic.py
+++ b/src/core/logic.py
@@ -525,6 +525,12 @@ def get_settings_to_edit(display_group, journal, user):
                                                       'display_journal_title',
                                                       journal),
             },
+            {
+                'name': 'table_default_page_length',
+                'object': setting_handler.get_setting('styling',
+                                                      'table_default_page_length',
+                                                      journal),
+            },
         ]
         setting_group = 'styling'
     elif display_group == 'editorial':

--- a/src/templates/admin/elements/datatables.html
+++ b/src/templates/admin/elements/datatables.html
@@ -12,7 +12,9 @@ $(document).ready(function() {
     {% if sort and order %}"order": [[ {{ sort }}, "{{ order }}" ]],{% endif %}
     {% if sort_list %}"order": [{{ sort_list }}],{% endif %}
     {% if disable_ordering %}"ordering": false,{% endif %}
-    {% if page_length %}"pageLength": {{ page_length }},{% endif %}
+    {% if journal_settings.styling.table_default_page_length %}"pageLength": {{ journal_settings.styling.table_default_page_length }},
+    {% else %}{% if page_length %}"pageLength": {{ page_length }}, {% endif %}
+    {% endif %}
     });
 } );
 

--- a/src/templates/admin/elements/forms/group_styling.html
+++ b/src/templates/admin/elements/forms/group_styling.html
@@ -1,6 +1,7 @@
 <div class="content">
     {% include "admin/elements/forms/field.html" with field=attr_form.full_width_navbar %}
-    <p class="help-text">{% trans 'Full Width Navbar only applies to the Material theme' %}.</p>
+    <p class="help-text" style="margin-bottom: 2rem;">{% trans 'Full Width Navbar only applies to the Material theme' %}.</p>
     {% include "admin/elements/forms/field.html" with field=edit_form.multi_page_editorial %}
     {% include "admin/elements/forms/field.html" with field=edit_form.display_journal_title %}
+    {% include "admin/elements/forms/field.html" with field=edit_form.table_default_page_length %}
 </div>

--- a/src/utils/install/journal_defaults.json
+++ b/src/utils/install/journal_defaults.json
@@ -1671,6 +1671,25 @@
     },
     {
         "group": {
+            "name": "styling"
+        },
+        "setting": {
+            "description": "Default page length for tables in the platform. If the value is 0, each table will have a custom length. To show all elements in all tables, use -1.",
+            "is_translatable": false,
+            "name": "table_default_page_length",
+            "pretty_name": "Table Default Page Length",
+            "type": "number"
+        },
+        "value": {
+            "default": "0"
+        },
+        "editable_by": [
+            "editor",
+            "journal-manager"
+        ]
+    },
+    {
+        "group": {
             "name": "article"
         },
         "setting": {


### PR DESCRIPTION
## Problem / Objective
In many scenarios, the current default pagination size of the tables greatly limits their operation and visibility, so it is expected that it can be a configurable value at the journal level. This decision is also based on the fact that the volume of information and current technology allow without problems to load greater volumes of information.

## Solution
The `table_default_page_length` configuration is created to allow you to select the default paging size for tables on the platform. There are some considerations for this numerical value:
- Entering `0` allows you to use the usual platform configuration, customized for each type of table
- Entering `-1` allows you to not limit the pagination of the tables, that is, it allows you to view all the records.
- Entering any other positive value allows you to limit the maximum pagination of the tables to that value.