### PR TITLE
Forms Updates

### DIFF
--- a/src/core/forms/forms.py
+++ b/src/core/forms/forms.py
@@ -165,9 +165,9 @@ class RegistrationForm(forms.ModelForm, CaptchaForm):
         )
         if enable_competing_interest_selections:
             self.fields['competing_interest_domains'] = forms.CharField(
-                label='Domains with Conflict of Interest',
+                label='Institutional Domains with Conflict of Interest',
                 required=False,
-                help_text=_('Hit Enter to add a new Domain. e.g., example.com.'),
+                help_text=_('Hit Enter to add a new domain of an institution with which you have a conflict of interest, e.g., example.com.'),
                 widget=forms.TextInput(attrs={
                     'id': 'id_domains',
                     'hidden': True,
@@ -273,9 +273,9 @@ class EditAccountForm(forms.ModelForm):
             )
             if enable_competing_interest_selections:
                 self.fields['competing_interest_domains'] = forms.CharField(
-                    label='Domains with Conflict of Interest',
+                    label='Institutional Domains with Conflict of Interest',
                     required=False,
-                    help_text=_('Hit Enter to add a new Domain. e.g., example.com.'),
+                    help_text=_('Hit Enter to add a new domain of an institution with which you have a conflict of interest, e.g., example.com.'),
                     widget=forms.TextInput(attrs={
                         'id': 'id_domains',
                         'hidden': True,

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -248,7 +248,7 @@ class Account(AbstractBaseUser, PermissionsMixin):
         verbose_name=_('Name suffix'),
     )
     biography = JanewayBleachField(null=True, blank=True, verbose_name=_('Biography'))
-    orcid = models.CharField(max_length=40, null=True, blank=True, verbose_name=_('ORCiD'))
+    orcid = models.CharField(max_length=40, null=True, blank=True, verbose_name=_('ORCiD'), help_text='The 16-digit number at the end of the ORCiD URL e.g. 0000-0000-0000-0000')
     institution = models.CharField(max_length=1000, null=True, blank=True, verbose_name=_('Institution'))
     department = models.CharField(max_length=300, null=True, blank=True, verbose_name=_('Department'))
     twitter = models.CharField(max_length=300, null=True, blank=True, verbose_name=_('Twitter Handle'))

--- a/src/templates/admin/elements/accounts/user_form.html
+++ b/src/templates/admin/elements/accounts/user_form.html
@@ -54,6 +54,11 @@
             </div>
         </div>
     </div>
+    <div class="large-12 columns">
+        <label for="id_interests">{% trans 'Review Keywords' %}</label>
+        <input type="text" id="id_interests" name="interests" value="{% for interest in user_to_edit.interest.all %}{{ interest }}{% if not forloop.last %},{% endif %}{% endfor %}"/>
+        <p class="help-text">{% trans 'Hit Enter to add a new interest' %}.</p>
+    </div>
     {% if journal_settings.general.enable_competing_interest_selections %}
     <div class="large-12 columns">
         {{ form.competing_interest_domains|foundation }}
@@ -92,10 +97,6 @@
     </div>
     <div class="large-6 columns">
         {{ form.signature|foundation }}
-    </div>
-    <div class="large-12 columns">
-        <label for="id_interests">{% trans 'Review Interests' %}</label>
-        <input type="text" id="id_interests" name="interests" value="{% for interest in user_to_edit.interest.all %}{{ interest }}{% if not forloop.last %},{% endif %}{% endfor %}"/> {% trans "Hit Enter to add a new interest" %}.
     </div>
 </div>
 

--- a/src/templates/admin/elements/metadata.html
+++ b/src/templates/admin/elements/metadata.html
@@ -66,7 +66,7 @@
         <th colspan="4">Comments to Editor</th>
     </tr>
     <tr>
-        <td colspan="4">{% if article.comments_editor %}{{ article.comments_editor|linebreaksbr }}{% else %}No comments{% endif %}
+        <td colspan="4">{% if article.comments_editor %}{{ article.comments_editor|safe }}{% else %}No comments{% endif %}
         </td>
     </tr>
     {% if request.journal.submissionconfiguration.competing_interests %}

--- a/src/templates/admin/repository/article.html
+++ b/src/templates/admin/repository/article.html
@@ -79,7 +79,7 @@
                         <th colspan="4">Comments to Editor</th>
                     </tr>
                     <tr>
-                        <td colspan="4">{% if preprint.comments_editor %}{{ preprint.comments_editor }}{% else %}No
+                        <td colspan="4">{% if preprint.comments_editor %}{{ preprint.comments_editor|safe }}{% else %}No
                             comments{% endif %}</td>
                     </tr>
                     {% for field_answer in preprint.additional_field_answers %}

--- a/src/templates/admin/repository/author_article.html
+++ b/src/templates/admin/repository/author_article.html
@@ -70,7 +70,7 @@
                             <th colspan="2">Comments to the Editor</th>
                         </tr>
                         <tr>
-                            <td colspan="2"><small>{{ preprint.comments_editor }}</small></td>
+                            <td colspan="2"><small>{{ preprint.comments_editor|safe }}</small></td>
                         </tr>
                         {% for field_answer in preprint.additional_field_answers %}
                         <tr>

--- a/src/templates/admin/review/unassigned_article.html
+++ b/src/templates/admin/review/unassigned_article.html
@@ -70,7 +70,7 @@
                         <th colspan="4">Comments to Editor</th>
                     </tr>
                     <tr>
-                        <td colspan="4">{% if article.comments_editor %}{{ article.comments_editor|linebreaksbr }}{% else %}No
+                        <td colspan="4">{% if article.comments_editor %}{{ article.comments_editor|safe }}{% else %}No
                             comments{% endif %}</td>
                     </tr>
                     {% if request.journal.submissionconfiguration.competing_interests %}

--- a/src/templates/admin/submission/start.html
+++ b/src/templates/admin/submission/start.html
@@ -74,6 +74,7 @@
 
                     {% if journal_settings.general.enable_competing_interest_selections %}
                     <p>{% trans "Search for users using the name. If an user is matched, they will be registered as a conflict of interest." %}</p>
+                    <p>{% trans "If you have any conflict of interests not already stated above, please state them in the text box." %}</p>
                     {% include "elements/dual_listbox/dual_listbox.html" with list_of_members=journal.editorial_members %}
                     {% endif %}
 

--- a/src/themes/OLH/templates/elements/accounts/user_form.html
+++ b/src/themes/OLH/templates/elements/accounts/user_form.html
@@ -59,6 +59,13 @@
         </div>
     </div>
 </div>
+<div class="row">
+    <div class="large-12 columns">
+        <label for="id_interests">{% trans 'Review Keywords' %}</label>
+        <input type="text" id="id_interests" name="interests" value="{% for interest in user_to_edit.interest.all %}{{ interest }}{% if not forloop.last %},{% endif %}{% endfor %}"/>
+        <p class="help-text">{% trans 'Hit Enter to add a new interest' %}.</p>
+    </div>
+</div>
 {% if journal_settings.general.enable_competing_interest_selections %}
 <div class="row">
     <div class="large-12 columns">
@@ -98,10 +105,6 @@
     </div>
     <div class="large-6 columns">
         {{ form.signature|foundation }}
-    </div>
-    <div class="large-12 columns">
-        <label for="id_interests">{% trans 'Review Interests' %}</label>
-        <input type="text" id="id_interests" name="interests" value="{% for interest in user_to_edit.interest.all %}{{ interest }}{% if not forloop.last %},{% endif %}{% endfor %}"/> {% trans 'Hit Enter to add a new interest' %}.
     </div>
 </div>
 

--- a/src/themes/clean/templates/elements/accounts/user_form.html
+++ b/src/themes/clean/templates/elements/accounts/user_form.html
@@ -42,6 +42,13 @@
         {% bootstrap_field form.secondary_study_topic %}
     </div>
 </div>
+<div class="row">
+    <div class="col-md-12">
+        <label for="id_interests">{% trans 'Review Keywords' %}</label>
+        <input type="text" id="id_interests" name="interests" value="{% for interest in user_to_edit.interest.all %}{{ interest }}{% if not forloop.last %},{% endif %}{% endfor %}"/>
+        <p class="help-text">{% trans 'Hit Enter to add a new interest' %}.</p>
+    </div>
+</div>
 {% if journal_settings.general.enable_competing_interest_selections %}
 <div class="row">
     <div class="col-md-12">
@@ -81,10 +88,6 @@
     </div>
     <div class="col-md-6">
         {% bootstrap_field form.signature %}
-    </div>
-    <div class="col-md-12">
-        <label for="id_interests">{% trans 'Review Interests' %}</label>
-        <input type="text" id="id_interests" name="interests" value="{% for interest in user_to_edit.interest.all %}{{ interest }}{% if not forloop.last %},{% endif %}{% endfor %}"/> {% trans 'Hit Enter to add a new interest' %}.
     </div>
 </div>
 

--- a/src/themes/material/templates/elements/accounts/user_form.html
+++ b/src/themes/material/templates/elements/accounts/user_form.html
@@ -43,6 +43,13 @@
         {% bootstrap_field form.secondary_study_topic %}
     </div>
 </div>
+<div class="row">
+    <div class="col m12">
+        <label for="id_interests">{% trans "Review Keywords" %}</label>
+        <input type="text" id="id_interests" name="interests" value="{% for interest in user_to_edit.interest.all %}{{ interest }}{% if not forloop.last %},{% endif %}{% endfor %}"/>
+        <p class="help-text">{% trans 'Hit Enter to add a new interest' %}.</p>
+    </div>
+</div>
 {% if journal_settings.general.enable_competing_interest_selections %}
 <div class="row">
     <div class="col-md-12">
@@ -82,10 +89,6 @@
     </div>
     <div class="col m6">
         {% bootstrap_field form.signature %}
-    </div>
-    <div class="col m12">
-        <label for="id_interests">{% trans "Review Interests" %}</label>
-        <input type="text" id="id_interests" name="interests" value="{% for interest in user_to_edit.interest.all %}{{ interest }}{% if not forloop.last %},{% endif %}{% endfor %}"/> {% trans "Hit Enter to add a new interest" %}.
     </div>
 </div>
 


### PR DESCRIPTION

**Form Updates**

- Update Label for Domain Conflicts of Interest
    ```
    Institutional Domains with Conflict of Interest
    ```
- Update Help Text for Domain Conflicts of Interest
    ```
    Hit Enter to add a new domain of an institution with which you have a conflict of interest, e.g., example.com.
    ```
- Validate whether the ORCID input when creating and editing a user should be the full URL or just the code. Specify it in the Help Text of the field → just the code
- Update Label for interest selection field from **`Review Interest`** to **`Review Keywords`**
- Reposition interest keywords entry field so that it is next to Research Topics
- In the article submission form, when conflicts of interest must be selected and complemented, restructure both fields so that their use is clear and that they are complementary
    - Add conflict of interest text field information before selecting accounts with conflicts of interest. Validate informational framed use (blue text)
    ```
     If you have any conflict of interests not already stated above, please state them here.
     ```
- Correct Comments to Editor text display so that it is not visible with HTML tags. Validate and correct it in all its uses in the system