### PR TITLE
Rename Study Topics to Research Topics

### DIFF
--- a/src/core/forms/forms.py
+++ b/src/core/forms/forms.py
@@ -234,14 +234,14 @@ class EditAccountForm(forms.ModelForm):
         queryset=models.Topics.objects.none(),
         widget=Select2MultipleWidget,
         required=False,
-        label=_('Preferred Study Topics')
+        label=_('Primary Research Topics')
     )
     
     secondary_study_topic = forms.ModelMultipleChoiceField(
         queryset=models.Topics.objects.none(),
         widget=Select2MultipleWidget,
         required=False,
-        label=_('Another Study Topics')
+        label=_('Secondary Research Topics')
     )
 
     class Meta:

--- a/src/submission/forms.py
+++ b/src/submission/forms.py
@@ -203,18 +203,18 @@ class ArticleInfo(KeywordModelForm, JanewayTranslationModelForm):
                     queryset=topics_queryset,
                     widget=forms.Select,
                     required=True,
-                    label=_('Primary Study Topic'),
+                    label=_('Primary Research Topic'),
                     initial=article.topics('PR').first(),
-                    help_text='Main study topic of the article',
+                    help_text='Main research topic of the article',
                 )
     
                 self.fields['secondary_study_topic'] = forms.ModelMultipleChoiceField(
                     queryset=topics_queryset,
                     widget=Select2MultipleWidget,
                     required=False,
-                    label=_('Secondary Study Topic'),
+                    label=_('Secondary Research Topic'),
                     initial=article.topics('SE'),
-                    help_text='Anothers study topics related to the article',
+                    help_text='Anothers research topics related to the article',
                 )
 
                 study_topic_choices = [('', '---------')] + [

--- a/src/templates/admin/core/manager/topics/topic_list.html
+++ b/src/templates/admin/core/manager/topics/topic_list.html
@@ -25,7 +25,7 @@
             <div class="content">
                 <p>
                     {% blocktrans %}
-                        Here you can create and edit the journal study topics that classifiable an article. They allow you to give better recommendations for assigning users to the article
+                        Here you can create and edit the journal research topics that classifiable an article. They allow you to give better recommendations for assigning users to the article
                     {% endblocktrans %}
                 </p>
                 <p>
@@ -91,7 +91,7 @@
             <div class="content">
                 <p>
                     {% blocktrans %}
-                        Here you can create and edit the journal study topic groups.
+                        Here you can create and edit the journal research topic groups.
                     {% endblocktrans %}
                 </p>
                 <p>

--- a/src/templates/admin/elements/accounts/user_form.html
+++ b/src/templates/admin/elements/accounts/user_form.html
@@ -38,7 +38,7 @@
         <div class="large-6 columns" style="margin-bottom: 16px;">
             <div class="row expanded">
                 <div class="large-12 columns">
-                    <label for="id_topics">{% trans 'Preferred Study Topics' %}</label>
+                    <label for="id_topics">{% trans 'Primary Research Topics' %}</label>
                     {{ form.primary_study_topic }}
                 </div>
                 <p class="help-text" style="padding: 0 16px;">{{ form.primary_study_topic.help_text}}</p>
@@ -47,7 +47,7 @@
         <div class="large-6 columns" style="margin-bottom: 16px;">
             <div class="row expanded">
                 <div class="large-12 columns">
-                    <label for="id_topics">{% trans 'Another Study Topics' %}</label>
+                    <label for="id_topics">{% trans 'Secondary Research Topics' %}</label>
                     {{ form.secondary_study_topic }}
                 </div>
                 <p class="help-text" style="padding: 0 16px;">{{ form.secondary_study_topic.help_text}}</p>

--- a/src/templates/admin/elements/review/custom_review_meta_block.html
+++ b/src/templates/admin/elements/review/custom_review_meta_block.html
@@ -70,7 +70,7 @@
 
 {% if journal_settings.general.enable_study_topics %}
 <div class="title-area">
-    <h2>Study Topics</h2>
+    <h2>Research Topics</h2>
 </div>
 <div class="content">
     <table class="hover scroll">

--- a/src/templates/admin/elements/review/editor_assignment_request_metadata.html
+++ b/src/templates/admin/elements/review/editor_assignment_request_metadata.html
@@ -43,7 +43,7 @@
             <p>{{ assignment_request.article.get_language_display }}</p>
             
             {% if journal_settings.general.enable_study_topics %}
-            <p><strong>Study Topics</strong></p>
+            <p><strong>Research Topics</strong></p>
             {% include "admin/elements/review/assigned_topics_table.html" with topics_by_type=assignment_request.article.topics_by_type %}
             {% endif %}
         </div>

--- a/src/templates/admin/review/add_editor_assignment.html
+++ b/src/templates/admin/review/add_editor_assignment.html
@@ -54,11 +54,11 @@
                             <div class="switch tiny">
                                 <input class="autoSubmit switch-input" id="studyTopicSwitch" type="checkbox" name="view-study-topics" checked>
                                 <label class="switch-paddle" for="studyTopicSwitch">
-                                    <span class="show-for-sr">View Study Topics</span>
+                                    <span class="show-for-sr">View Research Topics</span>
                                 </label>
                             </div>
                         </span>
-                        <p>View Study Topics</p>
+                        <p>View Research Topics</p>
                     </div>
                     {% endif %}
 
@@ -71,9 +71,9 @@
                             <th>Type</th>
                             <th>Active Assignments</th>
                             <th width="40%" class="list-interests" {% if journal_settings.general.enable_study_topics %} hidden {% else %} show {% endif %}>Interests</th>
-                            <th width="40%" class="list-study-topics" {% if journal_settings.general.enable_study_topics %} show {% else %} hidden {% endif %}>Study Topics</th>
+                            <th width="40%" class="list-study-topics" {% if journal_settings.general.enable_study_topics %} show {% else %} hidden {% endif %}>Research Topics</th>
                             <th class="list-study-topics" {% if journal_settings.general.enable_study_topics %} show {% else %} hidden {% endif %}>
-                                {% include "elements/info_tooltip.html" with label_text='Match Score' info_message='Account score based on study topic matches.' %}
+                                {% include "elements/info_tooltip.html" with label_text='Match Score' info_message='Account score based on research topic matches.' %}
                             </th>
                         </tr>
                         </thead>

--- a/src/templates/admin/review/add_review_assignment.html
+++ b/src/templates/admin/review/add_review_assignment.html
@@ -58,11 +58,11 @@
                             <div class="switch tiny">
                                 <input class="autoSubmit switch-input" id="studyTopicSwitch" type="checkbox" name="view-study-topics" checked>
                                 <label class="switch-paddle" for="studyTopicSwitch">
-                                    <span class="show-for-sr">View Study Topics</span>
+                                    <span class="show-for-sr">View Research Topics</span>
                                 </label>
                             </div>
                         </span>
-                        <p>View Study Topics</p>
+                        <p>View Research Topics</p>
                     </div>
                     {% endif %}
 
@@ -74,9 +74,9 @@
                             <th>Email Address</th>
                             <th>Active Reviews</th>
                             <th width="30%" class="list-interests" {% if journal_settings.general.enable_study_topics %} hidden {% else %} show {% endif %}>Interests</th>
-                            <th width="30%" class="list-study-topics" {% if journal_settings.general.enable_study_topics %} show {% else %} hidden {% endif %}>Study Topics</th>
+                            <th width="30%" class="list-study-topics" {% if journal_settings.general.enable_study_topics %} show {% else %} hidden {% endif %}>Research Topics</th>
                             <th class="list-study-topics" {% if journal_settings.general.enable_study_topics %} show {% else %} hidden {% endif %}>
-                                {% include "elements/info_tooltip.html" with label_text='Match Score' info_message='Account score based on study topic matches.' %}
+                                {% include "elements/info_tooltip.html" with label_text='Match Score' info_message='Account score based on research topic matches.' %}
                             </th>
                             <th>
                                 {% include "elements/info_tooltip.html" with label_text='Average Score' info_message='Account score based on ratings.' %}

--- a/src/templates/admin/review/unassigned_article.html
+++ b/src/templates/admin/review/unassigned_article.html
@@ -120,7 +120,7 @@
         {% if journal_settings.general.enable_study_topics %}
         <div class="box">
             <div class="title-area">
-                <h2>Study Topics</h2>
+                <h2>Research Topics</h2>
             </div>
             <div class="content">
                 <table class="hover stack scroll" id="unassigned">

--- a/src/templates/admin/submission/edit/metadata.html
+++ b/src/templates/admin/submission/edit/metadata.html
@@ -99,7 +99,7 @@
                         <div class="large-3 columns" style="margin-bottom: 16px;">
                             <div class="row expanded">
                                 <div class="large-12 columns">
-                                    <label for="id_topics">{% trans 'Primary Study Topic' %}</label>
+                                    <label for="id_topics">{% trans 'Primary Research Topic' %}</label>
                                     {{ info_form.primary_study_topic }}
                                     <p class="help-text">{{ form.primary_study_topic.help_text}}</p>
                                 </div>
@@ -109,7 +109,7 @@
                         <div class="large-9 columns" style="margin-bottom: 16px;">
                             <div class="row expanded">
                                 <div class="large-12 columns">
-                                    <label for="id_topics">{% trans 'Secondary Study Topics' %}</label>
+                                    <label for="id_topics">{% trans 'Secondary Research Topics' %}</label>
                                     {{ info_form.secondary_study_topic }}
                                 </div>
                                 <p class="help-text" style="padding: 0 16px;">{{ form.secondary_study_topic.help_text}}</p>

--- a/src/templates/admin/submission/submit_info.html
+++ b/src/templates/admin/submission/submit_info.html
@@ -74,7 +74,7 @@
                             <div class="large-4 columns" style="margin-bottom: 16px;">
                                 <div class="row expanded">
                                     <div class="large-12 columns">
-                                        <label for="id_topics">{% trans 'Primary Study Topic' %}</label>
+                                        <label for="id_topics">{% trans 'Primary Research Topic' %}</label>
                                         {{ form.primary_study_topic }}
                                         <p class="help-text">{{ form.primary_study_topic.help_text}}</p>
                                     </div>
@@ -84,7 +84,7 @@
                             <div class="large-8 columns" style="margin-bottom: 16px;">
                                 <div class="row expanded">
                                     <div class="large-12 columns">
-                                        <label for="id_topics">{% trans 'Secondary Study Topics' %}</label>
+                                        <label for="id_topics">{% trans 'Secondary Research Topics' %}</label>
                                         {{ form.secondary_study_topic }}
                                     </div>
                                     <p class="help-text" style="padding: 0 16px;">{{ form.secondary_study_topic.help_text}}</p>

--- a/src/templates/admin/submission/submit_review.html
+++ b/src/templates/admin/submission/submit_review.html
@@ -99,7 +99,7 @@
                     {% if journal_settings.general.enable_study_topics %}
                     <table class="table small">
                         <tr>
-                            <th>Study Topics</th>
+                            <th>Research Topics</th>
                             <th>Type</th>
                         </tr>
                         {% for topic in article.topics_by_type.primary %}

--- a/src/themes/OLH/templates/elements/accounts/user_form.html
+++ b/src/themes/OLH/templates/elements/accounts/user_form.html
@@ -42,7 +42,7 @@
         <div class="large-6 columns" style="margin-bottom: 16px;">
             <div class="row expanded">
                 <div class="large-12 columns">
-                    <label for="id_topics">{% trans 'Preferred Study Topics' %}</label>
+                    <label for="id_topics">{% trans 'Primary Research Topics' %}</label>
                     {{ form.primary_study_topic }}
                 </div>
                 <p class="help-text" style="padding: 0 16px;">{{ form.primary_study_topic.help_text}}</p>
@@ -51,7 +51,7 @@
         <div class="large-6 columns" style="margin-bottom: 16px;">
             <div class="row expanded">
                 <div class="large-12 columns">
-                    <label for="id_topics">{% trans 'Another Study Topics' %}</label>
+                    <label for="id_topics">{% trans 'Secondary Research Topics' %}</label>
                     {{ form.secondary_study_topic }}
                 </div>
                 <p class="help-text" style="padding: 0 16px;">{{ form.secondary_study_topic.help_text}}</p>

--- a/src/utils/install/journal_defaults.json
+++ b/src/utils/install/journal_defaults.json
@@ -1864,10 +1864,10 @@
             "name": "general"
         },
         "setting": {
-            "description": "If enabled, Articles can be related to preconfigured study topics from the journal, with the purpose of improving review assignments based on account matches.",
+            "description": "If enabled, Articles can be related to preconfigured research topics from the journal, with the purpose of improving review assignments based on account matches.",
             "is_translatable": false,
             "name": "enable_study_topics",
-            "pretty_name": "Enable Study Topics",
+            "pretty_name": "Enable Research Topics",
             "type": "boolean"
         },
         "value": {


### PR DESCRIPTION
- Rename `Study Topics` references to `Research Topics` in templates, labels and help texts for a better understanding