### PR TITLE
fix catch exception when setting timezone in user profile

### DIFF
--- a/src/core/model_utils.py
+++ b/src/core/model_utils.py
@@ -709,7 +709,7 @@ class DynamicChoiceField(models.CharField):
         """
         try:
             super().validate(value, model_instance)
-        except exceptions.ValidationError as e:
+        except ValidationError as e:
             # If the raised exception is for invalid choice we check if the
             # choice is in dynamic choices.
             if e.code == 'invalid_choice':


### PR DESCRIPTION
## Problem / Objective
When a Timezone is chosen in the User Profile, an exception is triggered
```
...
NameError: name 'exceptions' is not defined
```
## Solution

```python
def validate(self, value, model_instance):
    """
    Validates value and throws ValidationError.
    """
    try:
        super().validate(value, model_instance)
    except ValidationError as e:
        # If the raised exception is for invalid choice we check if the
        # choice is in dynamic choices.
        if e.code == 'invalid_choice':
            potential_values = set(
                item[0] for item in self.dynamic_choices
            )
            if value not in potential_values:
                raise
```