### PR TITLE
Add enable_skip_send_email Configuration

### DIFF
--- a/src/core/logic.py
+++ b/src/core/logic.py
@@ -375,7 +375,7 @@ def get_settings_to_edit(display_group, journal, user):
                 'name': 'enable_invite_editor',
                 'object': setting_handler.get_setting('general', 'enable_invite_editor', journal),
             },
-             {
+            {
                 'name': 'enable_study_topics',
                 'object': setting_handler.get_setting('general', 'enable_study_topics', journal),
             },
@@ -447,6 +447,10 @@ def get_settings_to_edit(display_group, journal, user):
             {
                 'name': 'enable_competing_interest_selections',
                 'object': setting_handler.get_setting('general', 'enable_competing_interest_selections', journal),
+            },
+            {
+                'name': 'enable_skip_send_email',
+                'object': setting_handler.get_setting('general', 'enable_skip_send_email', journal),
             },
         ]
         setting_group = 'general'

--- a/src/templates/admin/elements/email_form.html
+++ b/src/templates/admin/elements/email_form.html
@@ -7,7 +7,7 @@
     <div class="card-divider">
         <div class="button-group">
             <button type="submit" class="button success" name="send"><i class="fa fa-envelope-o">&nbsp;</i>Send</button>
-            {% if skip %}
+            {% if skip and journal_settings.general.enable_skip_send_email %}
             <button type="submit" class="button warning" name="skip" value="skip"><i class="fa fa-step-forward">&nbsp;</i>Skip & continue</button>
             {% endif %}
             {% if cancel_url %}

--- a/src/templates/admin/elements/forms/group_review.html
+++ b/src/templates/admin/elements/forms/group_review.html
@@ -16,6 +16,7 @@
     {% include "admin/elements/forms/field.html" with field=edit_form.required_senior_editor %}
     {% include "admin/elements/forms/field.html" with field=edit_form.enable_invite_editor %}
     {% include "admin/elements/forms/field.html" with field=edit_form.enable_suggested_reviewers %}
+    {% include "admin/elements/forms/field.html" with field=edit_form.enable_skip_send_email %}
 </div>
 
 <div class="title-area">

--- a/src/utils/install/journal_defaults.json
+++ b/src/utils/install/journal_defaults.json
@@ -5501,5 +5501,24 @@
             "editor",
             "journal-manager"
         ]
+    },
+    {
+        "group": {
+            "name": "general"
+        },
+        "setting": {
+            "description": "If enabled, Editors can skip sending notification emails.",
+            "is_translatable": false,
+            "name": "enable_skip_send_email",
+            "pretty_name": "Enable Skip Send Email",
+            "type": "boolean"
+        },
+        "value": {
+            "default": "on"
+        },
+        "editable_by": [
+            "editor",
+            "journal-manager"
+        ]
     }
 ]


### PR DESCRIPTION
* Add `enable_skip_send_email` configuration to skip sending notification emails. By default, it is active
This will allow to disable and not allow skipping notification emails.

To enable or disable, go to Manager / Review Settings