### PR TITLE
Fix Condition to show Visibility Checkbox in add_files Template

### DIFF
--- a/src/templates/admin/review/add_files.html
+++ b/src/templates/admin/review/add_files.html
@@ -91,7 +91,6 @@
                     </table>
 
                     {% if journal_settings.general.default_review_visibility == 'double-blind' %}
-                    {{journal_settings.general.default_review_visibility}}
                     {{ journal_settings.general.review_file_help|safe }}
 
                     <input type="checkbox" id="anon" required>

--- a/src/templates/admin/review/add_files.html
+++ b/src/templates/admin/review/add_files.html
@@ -90,11 +90,12 @@
                         </tbody>
                     </table>
 
-                    {% if journal_settings.general.default_review_visibility == 'double-blind' or journal_settings.general.default_review_visibility == 'blind' %}
+                    {% if journal_settings.general.default_review_visibility == 'double-blind' %}
+                    {{journal_settings.general.default_review_visibility}}
                     {{ journal_settings.general.review_file_help|safe }}
 
                     <input type="checkbox" id="anon" required>
-                    <label for="anon">Review files have been anonymised or this paper is not being reviewed in single anonymous or double-anonymous peer review.</label>
+                    <label for="anon">Review files have been anonymised or this paper is not being reviewed in single anonymous.</label>
                     <br />
                     {% endif %}
 


### PR DESCRIPTION
Taking in consideration that
> Single-blind peer review is a conventional method of peer review where the authors do not know who the reviewers are. However, the reviewers know who the authors are. Whereas, double-blind peer review, is when neither authors nor reviewers know each other’s name or affiliations.
> [link](https://www.enago.com/academy/double-blind-peer-review-for-better-or-for-worse/#:~:text=Single%2Dblind%20peer%20review%20is%20a%20conventional%20method%20of%20peer,each%20other's%20name%20or%20affiliations.)

The condition to show the anonymity confirmation checkbox of uploaded files should only apply to double blinding.
that means
```jinja2
{% if journal_settings.general.default_review_visibility == 'double-blind' %}
    {{ journal_settings.general.review_file_help|safe }}

    <input type="checkbox" id="anon" required>
    <label for="anon">Review files have been anonymised or this paper is not being reviewed in single anonymous.</label>
    <br />
{% endif %}
```